### PR TITLE
ci: :construction_worker: semantic-releaseを導入し、リリースプロセスを自動化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,15 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.temp
+
+# Node.js dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build artifacts
+dist/
+
+# Semantic release
+CHANGELOG.md

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,54 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "make build-all",
+        "publishCmd": "echo 'Binary built successfully'"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          {
+            "path": "dist/redmine-linux-amd64",
+            "name": "redmine-linux-amd64",
+            "label": "Linux AMD64 Binary"
+          },
+          {
+            "path": "dist/redmine-linux-arm64",
+            "name": "redmine-linux-arm64",
+            "label": "Linux ARM64 Binary"
+          },
+          {
+            "path": "dist/redmine-darwin-amd64",
+            "name": "redmine-darwin-amd64",
+            "label": "macOS AMD64 Binary"
+          },
+          {
+            "path": "dist/redmine-darwin-arm64",
+            "name": "redmine-darwin-arm64",
+            "label": "macOS ARM64 Binary"
+          },
+          {
+            "path": "dist/redmine-windows-amd64.exe",
+            "name": "redmine-windows-amd64.exe",
+            "label": "Windows AMD64 Binary"
+          }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to Redmine CLI
+
+## Commit Message Convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) for automatic versioning and changelog generation.
+
+### Commit Message Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+- **feat**: A new feature (triggers a minor version bump)
+- **fix**: A bug fix (triggers a patch version bump)
+- **docs**: Documentation only changes
+- **style**: Changes that do not affect the meaning of the code
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **perf**: A code change that improves performance
+- **test**: Adding missing tests or correcting existing tests
+- **chore**: Changes to the build process or auxiliary tools
+
+### Breaking Changes
+
+To trigger a major version bump, add `BREAKING CHANGE:` in the commit body or add `!` after the type:
+
+```
+feat!: remove support for legacy config format
+
+BREAKING CHANGE: The old YAML configuration format is no longer supported.
+Please migrate to the new JSON format.
+```
+
+### Examples
+
+```bash
+# Minor version bump (new feature)
+feat: add tracker selection to issues add command
+
+# Patch version bump (bug fix)
+fix: resolve user email lookup in issues add
+
+# No version bump
+docs: update README with new command examples
+
+# Major version bump (breaking change)
+feat!: change CLI argument structure for better usability
+```
+
+## Release Process
+
+1. All changes should be made via Pull Requests to the `main` branch
+2. When PR is merged to `main`, GitHub Actions will:
+   - Run tests
+   - Build cross-platform binaries
+   - Analyze commit messages
+   - Generate changelog
+   - Create a GitHub release with version tag
+   - Upload binary assets to the release
+
+## Development
+
+### Building
+
+```bash
+# Build for current platform
+make build
+
+# Build for all platforms
+make build-all
+
+# Run tests
+make test
+```
+
+### Testing
+
+Make sure to add tests for new features and run the test suite before submitting PRs:
+
+```bash
+go test ./...
+```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: build build-all clean test
+
+# Default build for current platform
+build:
+	go build -o redmine .
+
+# Build for all platforms
+build-all: clean
+	mkdir -p dist
+	GOOS=linux GOARCH=amd64 go build -o dist/redmine-linux-amd64 .
+	GOOS=linux GOARCH=arm64 go build -o dist/redmine-linux-arm64 .
+	GOOS=darwin GOARCH=amd64 go build -o dist/redmine-darwin-amd64 .
+	GOOS=darwin GOARCH=arm64 go build -o dist/redmine-darwin-arm64 .
+	GOOS=windows GOARCH=amd64 go build -o dist/redmine-windows-amd64.exe .
+
+# Clean build artifacts
+clean:
+	rm -rf dist/
+	rm -f redmine
+
+# Run tests
+test:
+	go test ./...
+
+# Install dependencies
+install:
+	go mod download

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "redmine-cli",
+  "version": "0.0.0-development",
+  "description": "Command line interface for Redmine",
+  "main": "index.js",
+  "scripts": {
+    "semantic-release": "semantic-release"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/UNILORN/redmine-cli.git"
+  },
+  "keywords": [
+    "redmine",
+    "cli",
+    "command-line",
+    "go"
+  ],
+  "author": "UNILORN",
+  "license": "MIT",
+  "devDependencies": {
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/commit-analyzer": "^11.1.0",
+    "@semantic-release/exec": "^6.0.3",
+    "@semantic-release/git": "^10.0.1",
+    "@semantic-release/github": "^9.2.6",
+    "@semantic-release/release-notes-generator": "^12.1.0",
+    "semantic-release": "^22.0.12"
+  }
+}


### PR DESCRIPTION
リリース作業を自動化し、Conventional Commitsに基づいた一貫性のあるバージョン管理とチェンジログ生成を実現するためにsemantic-releaseを導入します。

主な変更点:
- `semantic-release`と関連プラグインを`package.json`に追加
- リリースフローを定義する`.releaserc.json`を追加
- クロスプラットフォームビルド用の`Makefile`を追加
- `CONTRIBUTING.md`にコミット規約とリリースプロセスを記載
- `node_modules`やビルド成果物を`.gitignore`に追加