### PR TITLE
ci: :construction_worker: @semantic-release/git プラグインを削除

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Install semantic-release dependencies
         run: |
           npm install -g semantic-release
-          npm install -g @semantic-release/git
           npm install -g @semantic-release/changelog
           npm install -g @semantic-release/exec
           npm install -g @semantic-release/github

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -42,13 +42,6 @@
           }
         ]
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
     ]
   ]
 }


### PR DESCRIPTION
@semantic-release/githubプラグインがリリースノートを含むGitHubリリースを作成するため、CHANGELOG.mdファイルをリポジトリにコミットバックする必要はなくなりました。

この変更により、CIワークフローから不要なnpmパッケージのインストールが削除され、リリースプロセスが簡素化されます。